### PR TITLE
secret key is query string parameter

### DIFF
--- a/Source/Azure.API3.Connection.pas
+++ b/Source/Azure.API3.Connection.pas
@@ -131,6 +131,7 @@ begin
 
   RRP := RESTRequest.Params.AddItem;
   RRP.name  := 'subscription-key';
+  RRP.Kind := TRESTRequestParameterKind.pkQUERY;
 
   RESTRequest.Resource := 'issuetoken';
   RESTRequest.SynchronizedEvents := False;

--- a/Source/Azure.API3.Connection.pas
+++ b/Source/Azure.API3.Connection.pas
@@ -249,6 +249,8 @@ end;
 
 constructor TAzureTransportBase.Create(AOwner: TComponent);
 begin
+  inherited Create(AOwner);
+
   FRESTClient := TRESTClient.Create(Self);
   FRestClient.ContentType := CONTENTTYPE_APPLICATION_JSON;
   FRestClient.Accept := 'application/json, text/plain; q=0.9, text/html;q=0.8,';


### PR DESCRIPTION
Sample app raises 401 access denied error. Related with issue from @DieterLudwig. Default parameter type that can be added to requests is pkGETorPOST. Since secret key is passed using query string parameter, pkQUERY should be used. Note that request is POST method. 

https://docs.microsoft.com/en-us/azure/cognitive-services/translator/reference/v3-0-reference#authenticating-with-an-access-token