### PR TITLE
fix malformating of audio data in the request body

### DIFF
--- a/Source/Azure.API3.Speech.SpeechToText.pas
+++ b/Source/Azure.API3.Speech.SpeechToText.pas
@@ -97,7 +97,7 @@ begin
   Assert(AInputStream <> nil,'Invalid Stream');
 
   if AInputStream is TStringStream then begin
-    RESTRequest.Body.JSONWriter.WriteRaw(TStringStream(AInputStream).DataString);
+    RESTRequest.AddBody(AInputStream, 'audio/wave');
   end
   else begin
   var SS := TStringStream.Create('');


### PR DESCRIPTION
for many wav files, the recognition results were unsuccessful or very strange due to some low-level issue of the audio data formatting in the request body

using the built-in method TRestRequest.AddBody() solves the problem