### PR TITLE
fix malformating of audio data in the request body

### DIFF
--- a/Source/Azure.API3.Speech.SpeechToText.pas
+++ b/Source/Azure.API3.Speech.SpeechToText.pas
@@ -97,7 +97,7 @@ begin
   Assert(AInputStream <> nil,'Invalid Stream');
 
   if AInputStream is TStringStream then begin
-    RESTRequest.AddBody(AInputStream, 'audio/wave');
+    RESTRequest.AddBody(AInputStream, TRestContentType.ctAUDIO_VND_WAVE);
   end
   else begin
   var SS := TStringStream.Create('');


### PR DESCRIPTION
generalize value of TRestContentType type parameter in the RESTRequest.AddBody() call

using implicit string value for this parameter leads to compile-time error on Delphi 10.4 Community Edition